### PR TITLE
Add ability to set a high water mark

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -68,6 +68,7 @@ Where:
 | @<bind>@              | The ØMQ socket will connect to the given address using "bind()":http://api.zeromq.org/2-1:zmq-bind method. Can be used only if socket is PUB or SUB type |
 | @<connect>@           | The ØMQ socket will connect to the given address using "connect()":http://api.zeromq.org/2-1:zmq-connect method  |
 | @<pattern>@		| The pattern defines the format of the ØMQ message that will be sent by the appender. The format used the same PatternLayout of the default Logback "ConsoleAppender":http://logback.qos.ch/manual/layouts.html#ClassicPatternLayout|
+| @<highWaterMark>@     | A high water mark for the socket, after which messages will be discarded (if they're not sent). This prevents infinite buffering (and ergo infinite RAM use) if the thing you are sending to is down. Defaults to 10000 messages |
 
 
 h2. Examples of use

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,15 @@
         </developer>
     </developers>
 
+    <licenses>
+      <license>
+        <name>The Apache Software License, Version 2.0</name>
+        <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        <distribution>repo</distribution>
+        <comments>A business-friendly OSS license</comments>
+      </license>
+    </licenses>
+
     <dependencies>
         <!--Only need Logback Core to compile -->
         <dependency>

--- a/src/main/java/org/tlrx/logback/appender/ZMQSocketAppender.java
+++ b/src/main/java/org/tlrx/logback/appender/ZMQSocketAppender.java
@@ -15,6 +15,7 @@ public class ZMQSocketAppender<E> extends OutputStreamAppender<E> {
     private String type;
     private String bind;
     private String connect;
+    private long highWaterMark = 10000L;
 
     private enum METHOD {
         BIND,
@@ -45,6 +46,14 @@ public class ZMQSocketAppender<E> extends OutputStreamAppender<E> {
 
     public void setType(String type) {
         this.type = type;
+    }
+
+    public long getHighWaterMark() {
+        return highWaterMark;
+    }
+
+    public void setHighWaterMark(long highWaterMark) {
+        this.highWaterMark = highWaterMark;
     }
 
     @Override
@@ -130,9 +139,15 @@ public class ZMQSocketAppender<E> extends OutputStreamAppender<E> {
                 break;
         }
 
+        if(highWaterMark<0){
+            addError("<highWaterMark> must not be >= 0");
+        }
+
         if (!error) {
             // Creates the zmq socket
             ZMQ.Socket socket = context.socket(socketType);
+
+            socket.setHWM(highWaterMark);
 
             if (method == METHOD.CONNECT) {
                 socket.connect(address);


### PR DESCRIPTION
Hiya

Please pull the following change to add a HWM setting. This is currently always set (as I think you always want it).

Let me know what you think of this change? If you feel that the HWM setting should be optional in some cases then let me know, as I'm happy to change as you think is required to get these upstreamed so we don't have to maintain.

Thanks in advance
Tomas
